### PR TITLE
Add dynamic user management with roles

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -24,11 +24,10 @@ export class Header {
     const userIdentifier = user ? user.email.split('@')[0] : 'Usuario';
     const isAdmin = user ? RolesService.isAdmin(user.email) : false;
     
-    console.log('🔍 Header Debug:', { 
-      user: user?.email, 
-      userIdentifier, 
+    console.log('🔍 Header Debug:', {
+      user: user?.email,
+      userIdentifier,
       isAdmin,
-      adminEmails: ['salvador.fernandez@salesianas.org', 'codocoderson@gmail.com'],
       authServiceCurrentUser: AuthService.currentUser?.email
     });
 
@@ -100,6 +99,12 @@ export class Header {
                 border-bottom: 1px solid #eee;
                 transition: background 0.2s;
               ">📁 Carga de Alumnos</div>
+              <div class="menu-item" data-action="gestionUsuarios" style="
+                padding: 0.7rem 1rem;
+                cursor: pointer;
+                border-bottom: 1px solid #eee;
+                transition: background 0.2s;
+              ">👥 Gestión de Usuarios</div>
               <div class="menu-item" data-action="borrarBD" style="
                 padding: 0.7rem 1rem;
                 cursor: pointer;
@@ -180,13 +185,19 @@ export class Header {
               alert('No hay clases disponibles');
             }
             break;
-          
+
           case 'cargaAlumnos':
-            window.dispatchEvent(new CustomEvent('navegacion', { 
+            window.dispatchEvent(new CustomEvent('navegacion', {
               detail: { vista: 'carga' }
             }));
             break;
-          
+
+          case 'gestionUsuarios':
+            window.dispatchEvent(new CustomEvent('navegacion', {
+              detail: { vista: 'usuarios' }
+            }));
+            break;
+
           case 'borrarBD':
             if (confirm('⚠️ ATENCIÓN: Esto BORRARÁ TODA la base de datos. ¿Está seguro?')) {
               if (confirm('Esta acción NO se puede deshacer. ¿Confirma que desea borrar TODOS los datos?')) {

--- a/src/main.js
+++ b/src/main.js
@@ -6,8 +6,10 @@ import { ClaseView } from './views/ClaseView.js';
 import { CargaAlumnosView } from './views/CargaAlumnosView.js';
 import { LoginView } from './views/LoginView.js';
 import { InformeView } from './views/InformeView.js';
+import { GestionUsuariosView } from './views/GestionUsuariosView.js';
 import { DatabaseService } from './services/database.js';
 import { AuthService } from './services/auth.js';
+import { UserService } from './services/users.js';
 import { FontSizeService } from './utils/fontsize.js';
 import { CleanupService } from './services/cleanup.js';
 
@@ -53,6 +55,7 @@ class App {
         menu: new MenuView(this.mainContainer),
         clase: new ClaseView(this.mainContainer),
         carga: new CargaAlumnosView(this.mainContainer),
+        usuarios: new GestionUsuariosView(this.mainContainer),
         informe: new InformeView(this.mainContainer)
       };
       console.log('✅ Vistas inicializadas');
@@ -176,6 +179,13 @@ class App {
         if (this.tabsNav) {
           this.tabsNav.clases = DatabaseService.getClases();
           this.tabsNav.render();
+        }
+      });
+
+      // Suscribirse a la lista de usuarios
+      await UserService.subscribeAll(() => {
+        if (this.currentView === this.views.usuarios) {
+          this.currentView.render();
         }
       });
 

--- a/src/services/roles.js
+++ b/src/services/roles.js
@@ -1,14 +1,15 @@
 import { ref, get, set } from 'firebase/database';
 import { db } from '../config/firebase';
-
-const ADMIN_EMAILS = [
-  'salvador.fernandez@salesianas.org',
-  'codocoderson@gmail.com'
-];
+import { UserService } from './users.js';
 
 export const RolesService = {
   isAdmin(email) {
-    return ADMIN_EMAILS.includes(email);
+    const user = UserService.getUserByEmail(email);
+    return user?.role === 'admin';
+  },
+
+  getRole(email) {
+    return UserService.getUserByEmail(email)?.role || null;
   },
 
   async getLastVisitedClass(email) {
@@ -33,4 +34,4 @@ export const RolesService = {
       console.error('Error al guardar la última clase visitada:', error);
     }
   }
-}; 
+};

--- a/src/services/users.js
+++ b/src/services/users.js
@@ -1,0 +1,52 @@
+import { ref, onValue, set } from 'firebase/database';
+import { initializeApp, deleteApp } from 'firebase/app';
+import { getAuth, createUserWithEmailAndPassword, signOut } from 'firebase/auth';
+import { auth, db } from '../config/firebase.js';
+
+// Global cache for users
+const cache = {
+  users: {}, // { uid: { email, role } }
+  loaded: false
+};
+
+let unsubscribe = null;
+
+export const UserService = {
+  subscribeAll(onUpdate) {
+    if (unsubscribe) unsubscribe();
+    const usersRef = ref(db, 'usuarios');
+    let first = true;
+    return new Promise(resolve => {
+      unsubscribe = onValue(usersRef, snapshot => {
+        cache.users = snapshot.val() || {};
+        cache.loaded = true;
+        if (onUpdate) onUpdate();
+        if (first) { first = false; resolve(); }
+      });
+    });
+  },
+
+  getUsers() {
+    return cache.users;
+  },
+
+  getUserByEmail(email) {
+    return Object.values(cache.users).find(u => u.email === email) || null;
+  },
+
+  isLoaded() {
+    return cache.loaded;
+  },
+
+  async addUser(email, password, role) {
+    const secondaryApp = initializeApp(auth.app.options, 'secondary');
+    const secondaryAuth = getAuth(secondaryApp);
+    try {
+      const cred = await createUserWithEmailAndPassword(secondaryAuth, email, password);
+      await set(ref(db, `usuarios/${cred.user.uid}`), { email, role });
+      await signOut(secondaryAuth);
+    } finally {
+      await deleteApp(secondaryApp);
+    }
+  }
+};

--- a/src/views/GestionUsuariosView.js
+++ b/src/views/GestionUsuariosView.js
@@ -1,0 +1,64 @@
+import { UserService } from '../services/users.js';
+
+export class GestionUsuariosView {
+  constructor(container) {
+    this.container = container;
+  }
+
+  render() {
+    UserService.subscribeAll(() => this.render());
+    const usuarios = UserService.getUsers();
+    const filas = Object.values(usuarios).map(u => `
+      <tr>
+        <td style="padding:0.5rem;border-bottom:1px solid #eee;">${u.email}</td>
+        <td style="padding:0.5rem;border-bottom:1px solid #eee;">${u.role}</td>
+      </tr>`).join('');
+
+    this.container.innerHTML = `
+      <div style="max-width:600px;margin:0 auto;">
+        <h2 style="margin-bottom:1rem;">👥 Gestión de Usuarios</h2>
+        <table style="width:100%;border-collapse:collapse;margin-bottom:1rem;">
+          <thead>
+            <tr><th style="text-align:left;padding:0.5rem;">Email</th><th style="text-align:left;padding:0.5rem;">Rol</th></tr>
+          </thead>
+          <tbody>${filas}</tbody>
+        </table>
+        <div style="display:flex;flex-direction:column;gap:0.5rem;">
+          <input id="nuevoEmail" type="email" placeholder="Correo" style="padding:0.5rem;border:1px solid #ccc;border-radius:4px;">
+          <input id="nuevoPassword" type="password" placeholder="Contraseña" style="padding:0.5rem;border:1px solid #ccc;border-radius:4px;">
+          <select id="nuevoRol" style="padding:0.5rem;border:1px solid #ccc;border-radius:4px;">
+            <option value="profesor">Profesor</option>
+            <option value="admin">Administrador</option>
+          </select>
+          <div id="usuarioError" style="color:#dc3545;font-size:0.9rem;"></div>
+          <div style="display:flex;gap:1rem;margin-top:0.5rem;">
+            <button id="btnCrear" style="padding:0.5rem 1rem;background:#0044cc;color:white;border:none;border-radius:4px;cursor:pointer;">Crear</button>
+            <button id="btnVolver" style="padding:0.5rem 1rem;background:#fff;border:1px solid #ccc;border-radius:4px;cursor:pointer;">Volver</button>
+          </div>
+        </div>
+      </div>`;
+
+    document.getElementById('btnCrear').onclick = async () => {
+      const email = document.getElementById('nuevoEmail').value.trim();
+      const password = document.getElementById('nuevoPassword').value.trim();
+      const role = document.getElementById('nuevoRol').value;
+      const errorEl = document.getElementById('usuarioError');
+      errorEl.textContent = '';
+      if (!email || !password) {
+        errorEl.textContent = 'Email y contraseña requeridos';
+        return;
+      }
+      try {
+        await UserService.addUser(email, password, role);
+        document.getElementById('nuevoEmail').value = '';
+        document.getElementById('nuevoPassword').value = '';
+      } catch (e) {
+        errorEl.textContent = e.message;
+      }
+    };
+
+    document.getElementById('btnVolver').onclick = () => {
+      window.dispatchEvent(new CustomEvent('navegacion', { detail: { vista: 'menu' } }));
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- implement a new `UserService` for caching users and creating accounts without affecting the current session
- extend `RolesService` to read roles from `UserService`
- add a GestionUsuariosView for admins to create users and view roles
- add new admin menu option and navigation handling
- integrate user subscription in app startup

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6886adb2c8548331b9ead21d33add7e3