### PR TITLE
Registrar última clase visitada al navegar

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -178,6 +178,7 @@ class App {
 
       if (vista === 'clase') {
         this.currentView.render(params.clase);
+        AuthService.updateLastVisitedClass(params.clase);
       } else if (vista === 'informe') {
         this.currentView.render(params.clase, params.alumnoId);
       } else {


### PR DESCRIPTION
## Summary
- registra la clase activa cada vez que se muestra la vista de clase
- se mantiene el uso de la última clase visitada al arrancar el menú

## Testing
- `npm test` *(Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688ed74a5f58833194e6ef008bfb01ae